### PR TITLE
Missing coma in decide.urls.py

### DIFF
--- a/decide/decide/urls.py
+++ b/decide/decide/urls.py
@@ -22,7 +22,7 @@ from rest_framework_swagger.views import get_swagger_view
 schema_view = get_swagger_view(title='Decide API')
 
 urlpatterns = [
-    path('admin/', admin.site.urls)
+    path('admin/', admin.site.urls),
     path('doc/', schema_view),
     path('gateway/', include('gateway.urls')),
 ]


### PR DESCRIPTION
This PR addresses the missing comma in the linked issue

Closes #1 